### PR TITLE
hw: fix vga RGB widths

### DIFF
--- a/hw/iguana_chip.sv
+++ b/hw/iguana_chip.sv
@@ -191,11 +191,11 @@ module iguana_chip import iguana_pkg::*; import cheshire_pkg::*; (
   mc_pad_io     pad_slink_3_o   ( .pad_io ( slink_3_o   ), .d_i ( soc_slink_o[0][3]  ), .oe_i ( 1'b1 ), .d_o ( ) );
 
   // VGA interface
-  logic                      soc_vga_hsync_o;
-  logic                      soc_vga_vsync_o;
-  logic [VgaOutRedWidth-1:0] soc_vga_red_o;
-  logic [VgaOutRedWidth-1:0] soc_vga_green_o;
-  logic [VgaOutRedWidth-1:0] soc_vga_blue_o;
+  logic                        soc_vga_hsync_o;
+  logic                        soc_vga_vsync_o;
+  logic [  VgaOutRedWidth-1:0] soc_vga_red_o;
+  logic [VgaOutGreenWidth-1:0] soc_vga_green_o;
+  logic [ VgaOutBlueWidth-1:0] soc_vga_blue_o;
 
   mc_pad_io     pad_vga_hsync   ( .pad_io ( vga_hsync_o   ), .d_i ( soc_vga_hsync_o    ), .oe_i ( 1'b1 ), .d_o ( ) );
   mc_pad_io     pad_vga_vsync   ( .pad_io ( vga_vsync_o   ), .d_i ( soc_vga_vsync_o    ), .oe_i ( 1'b1 ), .d_o ( ) );

--- a/hw/iguana_soc.sv
+++ b/hw/iguana_soc.sv
@@ -51,9 +51,9 @@ module iguana_soc import iguana_pkg::*; import cheshire_pkg::*; (
   // VGA interface
   output logic                                  vga_hsync_o,
   output logic                                  vga_vsync_o,
-  output logic [VgaOutRedWidth-1:0]  vga_red_o,
-  output logic [VgaOutRedWidth-1:0]  vga_green_o,
-  output logic [VgaOutRedWidth-1:0]  vga_blue_o,
+  output logic [  VgaOutRedWidth-1:0]  vga_red_o,
+  output logic [VgaOutGreenWidth-1:0]  vga_green_o,
+  output logic [ VgaOutBlueWidth-1:0]  vga_blue_o,
   // Hyperbus
   output logic [HypNumPhys-1:0][HypNumChips-1:0]  hyper_cs_no,
   output logic [HypNumPhys-1:0]                   hyper_ck_o,


### PR DESCRIPTION
Fixes some type setting all widths to the
red bit-width.
The previous version also worked but more accidentally.